### PR TITLE
fix(radio): fix SX1262 image calibration leaving radio on the wrong frequency

### DIFF
--- a/src/radio/SX1262.cpp
+++ b/src/radio/SX1262.cpp
@@ -197,7 +197,15 @@ void SX1262::waitOnBusy() {
     unsigned long t = millis();
     if (_busy != -1) {
         while (digitalRead(_busy) == HIGH) {
-            if (millis() >= (t + 100)) break;
+            // CalibrateImage on a fresh (uncached) band can legitimately run
+            // longer than other opcodes. The old 100ms cap could give up
+            // while BUSY was still genuinely asserted — the chip ignores SPI
+            // while busy, so the SetRfFrequency write right after a band
+            // switch would land on a still-busy chip and get silently
+            // dropped, leaving the old frequency in effect. 1000ms is well
+            // beyond any documented SX126x opcode duration, so this only
+            // changes behavior in the case that was previously broken.
+            if (millis() >= (t + 1000)) break;
             yield();
         }
     }
@@ -252,6 +260,14 @@ bool SX1262::calibrate_image(uint32_t frequency) {
     uint8_t mode_byte = MODE_STDBY_RC_6X;
     executeOpcode(OP_STANDBY_6X, &mode_byte, 1);
     executeOpcode(OP_CALIBRATE_IMAGE_6X, image_freq, 2);
+    // Same as calibrate() above: BUSY needs a moment to assert after the
+    // opcode before waitOnBusy()'s poll loop means anything. Without this,
+    // waitOnBusy() can return immediately (BUSY hasn't risen yet) while
+    // CalibrateImage is still running, and the SetRfFrequency that
+    // setFrequency() issues right after lands mid-calibration and gets
+    // dropped — chip stays on the old band's frequency even though
+    // _imageCalBand now (wrongly) claims the new band is cached.
+    delay(5);
     waitOnBusy();
     _imageCalBand = band;
     Serial.printf("[SX1262] Image calibrated for %lu Hz (0x%02X 0x%02X)\n",

--- a/src/radio/SX1262.cpp
+++ b/src/radio/SX1262.cpp
@@ -242,7 +242,15 @@ bool SX1262::calibrate_image(uint32_t frequency) {
 
     if (_imageCalBand == band) return true;
 
-    standby();
+    // CalibrateImage must be issued from STDBY_RC per datasheet, same as
+    // Calibrate() above. standby() would enter STDBY_XOSC on this TCXO
+    // board, which leaves the image/PLL calibration for the new band
+    // invalid — symptom: after switching bands (e.g. Americas -> Europe),
+    // SetRfFrequency below appears to apply, but the chip stays locked on
+    // the previously-calibrated band's frequency until a later call skips
+    // this (now band-cached) step and re-issues a clean SetRfFrequency.
+    uint8_t mode_byte = MODE_STDBY_RC_6X;
+    executeOpcode(OP_STANDBY_6X, &mode_byte, 1);
     executeOpcode(OP_CALIBRATE_IMAGE_6X, image_freq, 2);
     waitOnBusy();
     _imageCalBand = band;


### PR DESCRIPTION
## Summary

Fixes the root cause behind #19: after switching to a configured frequency in a different ISM band from the 915MHz boot default, the SX1262 silently stays on the old frequency until any radio setting is reconfirmed in Settings without a reboot. That "fix" doesn't actually fix anything — it just skips the broken calibration path on the second call.

Two bugs in `calibrate_image()` / `waitOnBusy()` combine to cause this, both in `src/radio/SX1262.cpp`:

1. **`calibrate_image()` issued `CalibrateImage` from `STDBY_XOSC`, not `STDBY_RC`.** The SX1262 datasheet requires `STDBY_RC` for this opcode, same as the general `Calibrate()` a few lines above it (which already forced `STDBY_RC` explicitly) — `calibrate_image()` was missing the same fix.

2. **`waitOnBusy()` capped its poll at 100ms.** `CalibrateImage` on a fresh, never-calibrated band can legitimately run longer than that on this hardware. When the cap hit, the function returned while BUSY was still genuinely asserted. The SX126x ignores SPI while busy, so the `SetRfFrequency` write issued immediately after by `setFrequency()` landed on a still-busy chip and was silently dropped — frequency stayed on the old band even though `_imageCalBand` now (wrongly) recorded the new band as calibrated.

Because `_imageCalBand` caches per-band and skips recalibration once a band is marked done, both bugs produce the same masking symptom: reopening Settings and reconfirming any value calls `setFrequency()` again, but `_imageCalBand` already matches the target band, so the broken calibration step is skipped entirely and a clean `SetRfFrequency` goes through on an otherwise idle chip — "fixing" it until the next reboot.

## Changes

- Issue `CalibrateImage` from `STDBY_RC` explicitly, matching `Calibrate()`.
- Raise the `waitOnBusy()` poll cap from 100ms to 1000ms (well beyond any documented SX126x opcode duration).
- Add the same settle delay before `waitOnBusy()` that `calibrate()` already has, since `CalibrateImage` has the same BUSY-assertion-propagation gap.

Both fixes have been running on a downstream fork (rsCardputer-CE) since v0.0.5 with no recurrence of the stuck-frequency symptom.

## Test plan

- [x] Builds clean for `standalone_915` via `pio run -e standalone_915`
- [x] Switched from boot default (915MHz) to a custom 868MHz frequency via Settings, rebooted, radio came up on the new frequency immediately — no reconfirm-without-reboot workaround needed